### PR TITLE
Fixed the info message when no project name found

### DIFF
--- a/mk-project
+++ b/mk-project
@@ -399,7 +399,7 @@ while [ -n "$1" ]; do
 done
 
 if [ -z "$projectname" ]; then
-	echo "No se ha indicado el nombre del proyecto. Indícalo con la opción '-f' o '--project-name', si se está usando la opción '--all' solo escribe a el nombre del proyecto después del '--all'"
+	echo "No se ha indicado el nombre del proyecto. Indícalo con la opción '-f' o '--project-name'"
 	exit -1
 fi
 

--- a/mk-project
+++ b/mk-project
@@ -399,7 +399,7 @@ while [ -n "$1" ]; do
 done
 
 if [ -z "$projectname" ]; then
-	echo "No se ha indicado el nombre del proyecto. Indícalo con la opción '-p'"
+	echo "No se ha indicado el nombre del proyecto. Indícalo con la opción '-f' o '--project-name', si se está usando la opción '--all' solo escribe a el nombre del proyecto después del '--all'"
 	exit -1
 fi
 


### PR DESCRIPTION
I changed the error message when the script doesn't find the project name because the error-info message shows the option **'-p'** but this option is for the parcel installation.